### PR TITLE
[feature/version catalog] Gradle Version Catalog 적용

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'com.android.application'
-    id 'org.jetbrains.kotlin.android'
+    alias libs.plugins.android.application
+    alias libs.plugins.kotlin.android
 }
 
 android {
@@ -24,20 +24,21 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
 }
 
 dependencies {
-
-    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.6.1'
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    implementation libs.core.ktx
+    implementation libs.bundles.compose
+    implementation libs.appcompat
+    implementation libs.material
+    testImplementation libs.junit
+    androidTestImplementation libs.bundles.compose.test
+    androidTestImplementation libs.bundles.android.test
+    debugImplementation libs.bundles.compose.android.test
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.3.0' apply false
-    id 'com.android.library' version '7.3.0' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
+    alias libs.plugins.android.application apply false
+    alias libs.plugins.android.library apply false
+    alias libs.plugins.kotlin.android apply false
+}
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ corektx = "1.9.0"
 appcompat = "1.5.1"
 material = "1.6.1"
 junit = "4.13.2"
-androidx-test-junit = "1.1.4"
+androidx-test-junit = "1.1.3"
 androidx-test-espresso = "3.4.0"
 gradleplugin = "7.3.0"
 
@@ -20,8 +20,6 @@ compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "
 compose-junit = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
 compose-ui-test = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
-compose-ui-tooling-preview-test = { module = "androidx.compose.ui:ui-tooling-preview-test", version.ref = "compose" }
-compose-ui-tooling-test = { module = "androidx.compose.ui:ui-tooling-test", version.ref = "compose" }
 junit = { module = "junit:junit", version.ref = "junit" }
 androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-test-junit" }
 androidx-test-espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-test-espresso" }
@@ -29,7 +27,7 @@ androidx-test-espresso = { module = "androidx.test.espresso:espresso-core", vers
 [bundles]
 compose = ["compose-ui", "compose-ui-tooling", "compose-material", "compose-runtime", "compose-ui-tooling-preview"]
 compose-test = ["compose-junit"]
-compose-android-test = [ "compose-ui-test", "compose-ui-tooling-preview-test", "compose-ui-tooling-test"]
+compose-android-test = ["compose-ui-test"]
 android-test = ["androidx-test-junit", "androidx-test-espresso"]
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,39 @@
+[versions]
+kotlin = "1.7.0"
+compose = "1.2.1"
+corektx = "1.9.0"
+appcompat = "1.5.1"
+material = "1.6.1"
+junit = "4.13.2"
+androidx-test-junit = "1.1.4"
+androidx-test-espresso = "3.4.0"
+gradleplugin = "7.3.0"
+
+[libraries]
+core-ktx = { module = "androidx.core:core-ktx", version.ref = "corektx" }
+appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
+material = { module = "com.google.android.material:material", version.ref = "material" }
+compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
+compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
+compose-material = { module = "androidx.compose.material:material", version.ref = "compose" }
+compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
+compose-junit = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
+compose-ui-test = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose" }
+compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
+compose-ui-tooling-preview-test = { module = "androidx.compose.ui:ui-tooling-preview-test", version.ref = "compose" }
+compose-ui-tooling-test = { module = "androidx.compose.ui:ui-tooling-test", version.ref = "compose" }
+junit = { module = "junit:junit", version.ref = "junit" }
+androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-test-junit" }
+androidx-test-espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-test-espresso" }
+
+[bundles]
+compose = ["compose-ui", "compose-ui-tooling", "compose-material", "compose-runtime", "compose-ui-tooling-preview"]
+compose-test = ["compose-junit"]
+compose-android-test = [ "compose-ui-test", "compose-ui-tooling-preview-test", "compose-ui-tooling-test"]
+android-test = ["androidx-test-junit", "androidx-test-espresso"]
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "gradleplugin" }
+android-library = { id = "com.android.library", version.ref = "gradleplugin" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 19 23:48:12 KST 2022
+#Tue Sep 20 03:14:13 KST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- [Renovate의 원활한 활용](https://docs.renovatebot.com/java/)과 조금 더 편안한 버전관리를 위해 Gradle에서 오피셜하게 제공하는 Version Catalog 기능을 활용해볼까 합니다.

**Reference**

- [링크](https://docs.gradle.org/current/userguide/platforms.html)